### PR TITLE
Don't depend on Emacs 23

### DIFF
--- a/vhdl-capf.el
+++ b/vhdl-capf.el
@@ -4,7 +4,6 @@
 ;;
 ;; Author: sh-ow <sh-ow@users.noreply.github.com>
 ;; URL: https://github.com/sh-ow/vhdl-capf
-;; Package-Requires: ((emacs "23"))
 ;; Version: 0.1
 ;; Keywords: convenience, usability, vhdl, completion
 


### PR DESCRIPTION
The only version of package.el which works in Emacs 23 will fail to parse this "virtual" package dependency.

In connection with https://github.com/melpa/melpa/pull/3599
